### PR TITLE
Randomize encounter spawns and restore NPC collisions

### DIFF
--- a/src/gameobjects/Feissari.js
+++ b/src/gameobjects/Feissari.js
@@ -8,8 +8,9 @@ export class Feissari extends Physics.Arcade.Sprite {
         scene.physics.add.existing(this);
 
         this.setDisplaySize(64, 64);
-        this.body.setSize(64, 64);
+        this.body.setSize(64, 64, true);
         this.setImmovable(true);
+        this.triggered = false;
     }
 
     reset() {
@@ -17,6 +18,9 @@ export class Feissari extends Physics.Arcade.Sprite {
     }
 
     trigger(player, onComplete) {
+        if (this.triggered) return;
+        this.triggered = true;
+
         // Pysäytä pelaaja
         player.state = "stunned";
         player.setVelocity(0);
@@ -37,6 +41,24 @@ export class Feissari extends Physics.Arcade.Sprite {
             player.state = "can_move";
             if (onComplete) onComplete();
         });
+    }
+
+    activateAt(x, y) {
+        this.setPosition(x, y);
+        this.triggered = false;
+        this.setActive(true);
+        this.setVisible(true);
+        if (this.body) {
+            this.body.enable = true;
+        }
+    }
+
+    deactivate() {
+        this.setActive(false);
+        this.setVisible(false);
+        if (this.body) {
+            this.body.enable = false;
+        }
     }
 }
 

--- a/src/gameobjects/GrilliKaveri.js
+++ b/src/gameobjects/GrilliKaveri.js
@@ -8,13 +8,31 @@ export class GrilliKaveri extends Physics.Arcade.Sprite {
         scene.physics.add.existing(this);
 
         this.setDisplaySize(64, 64);
-        this.body.setSize(64, 64);
+        this.body.setSize(64, 64, true);
         this.setImmovable(true);
         this.triggered = false;
     }
 
     reset() {
         this.triggered = false;
+    }
+
+    activateAt(x, y) {
+        this.reset();
+        this.setPosition(x, y);
+        this.setActive(true);
+        this.setVisible(true);
+        if (this.body) {
+            this.body.enable = true;
+        }
+    }
+
+    deactivate() {
+        this.setActive(false);
+        this.setVisible(false);
+        if (this.body) {
+            this.body.enable = false;
+        }
     }
 
     trigger(player) {


### PR DESCRIPTION
## Summary
- align Feissari and GrilliKaveri physics bodies with their new sprites so collisions register again
- spawn Feissari, GrilliKaveri, and the Pomo call trigger at random street positions only after the game starts
- allow 1-10 Feissari to appear each day and refresh all encounters between days

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dece1d0b888329bd19ec79774100e4